### PR TITLE
Store customFields in customFields subobject

### DIFF
--- a/server/lib/sync-agent.js
+++ b/server/lib/sync-agent.js
@@ -85,7 +85,7 @@ class SyncAgent {
         ];
         return this.nutshellClient.findCustomFields(options).then((opsResult) => {
           const customFields = _.map(opsResult.result.Accounts, (field) => {
-            return { value: field.name, label: field.name };
+            return { value: `customFields.${field.name}`, label: field.name };
           });
 
           return _.concat(defaultFields, customFields);
@@ -119,7 +119,7 @@ class SyncAgent {
         ];
         return this.nutshellClient.findCustomFields(options).then((opsResult) => {
           const customFields = _.map(opsResult.result.Contacts, (field) => {
-            return { value: field.name, label: field.name };
+            return { value: `customFields.${field.name}`, label: field.name };
           });
 
           return _.concat(defaultFields, customFields);
@@ -154,7 +154,7 @@ class SyncAgent {
         ];
         return this.nutshellClient.findCustomFields(options).then((opsResult) => {
           const customFields = _.map(opsResult.result.Leads, (field) => {
-            return { value: field.name, label: field.name };
+            return { value: `customFields.${field.name}`, label: field.name };
           });
 
           return _.concat(defaultFields, customFields);

--- a/test/integration/fields-lead.e2e.spec.js
+++ b/test/integration/fields-lead.e2e.spec.js
@@ -108,7 +108,7 @@ describe("fieldsLeadAction", () => {
     ];
 
     const customFields = customFieldsData.result.Leads.map((cf) => {
-      return { value: cf.name, label: cf.name };
+      return { value: `customFields.${cf.name}`, label: cf.name };
     });
 
     const res = fieldsLeadAction(req, responseMock);


### PR DESCRIPTION
To prevent `Field 'Utm_Source' is a custom field. Please put custom fields in the 'customFields' sub-array` error